### PR TITLE
refactor: 크롤링 데이터 전처리 리팩터링

### DIFF
--- a/assets/popup/popup.js
+++ b/assets/popup/popup.js
@@ -156,9 +156,7 @@ async function addLinkAndMajor(majorLink = 'https://cse.pusan.ac.kr/cse/14651/su
   const studentSupply = document.querySelector('.studentSupply');
   const yourMajor = document.querySelector('.yourMajor');
   const Setting = await localStorageGet();
-
   yourMajor.innerText = Setting.mymajor;
-  console.log(Setting);
 
   studentSupply.addEventListener('click', () => {
     chrome.tabs.create({

--- a/scripts/notification.js
+++ b/scripts/notification.js
@@ -1,5 +1,6 @@
 import { getMajorNotices, getSchedules } from './crawling.js';
 import { localStorageSet } from './storage.js';
+import preprocessAndUpload from './preprocess.js';
 
 const createNotificationSignal = () => {
   chrome.runtime.onMessage.addListener((request, sender, sendResponse) => {
@@ -49,14 +50,7 @@ const createNotification = () => {
   chrome.alarms.onAlarm.addListener(async (alarm) => {
     const schedules = await getSchedules();
     const majorNotices = await getMajorNotices();
-    const fixedNotices = [];
-    const nonfixedNotices = [];
-    majorNotices.forEach((notice) => {
-      if (notice.articleTitle.startsWith('[ 일반공지 ]')) {
-        fixedNotices.push(notice);
-      } else nonfixedNotices.push(notice);
-    });
-    localStorageSet({ schedules, fixedNotices, nonfixedNotices });
+    preprocessAndUpload(schedules, majorNotices);
     // setTimeout(() => {
     //   localStorageSet({
     //     fixedNotices: [

--- a/scripts/preprocess.js
+++ b/scripts/preprocess.js
@@ -1,0 +1,22 @@
+/* eslint-disable no-param-reassign */
+import { localStorageSet } from './storage.js';
+
+export default function preprocessAndUpload(schedules, majorNotices) {
+  const fixedNotices = [];
+  const nonfixedNotices = [];
+
+  schedules.forEach((schedule) => {
+    const sDay = schedule.duration.substr(0, 10);
+    const eDay = schedule.duration.substr(17, 10);
+    schedule.startDay = sDay;
+    schedule.endDay = eDay;
+  });
+
+  majorNotices.forEach((notice) => {
+    if (notice.articleTitle.startsWith('[ 일반공지 ]')) {
+      fixedNotices.push(notice);
+    } else nonfixedNotices.push(notice);
+  });
+
+  localStorageSet({ schedules, fixedNotices, nonfixedNotices });
+}

--- a/service-worker.js
+++ b/service-worker.js
@@ -1,8 +1,9 @@
 /* eslint-disable no-param-reassign */
 import { getMajorNotices, getSchedules } from './scripts/crawling.js';
 import { createNotification, createNotificationSignal } from './scripts/notification.js';
-import settingData from './scripts/setting.js';
 import { localStorageGet, localStorageSet } from './scripts/storage.js';
+import settingData from './scripts/setting.js';
+import preprocessAndUpload from './scripts/preprocess.js';
 
 function openModal() {
   chrome.windows.create({
@@ -19,23 +20,8 @@ chrome.runtime.onInstalled.addListener(async ({ reason }) => {
     openModal();
     const schedules = await getSchedules();
     const majorNotices = await getMajorNotices();
-    const fixedNotices = [];
-    const nonfixedNotices = [];
 
-    schedules.forEach((schedule) => {
-      const sDay = schedule.duration.substr(0, 10);
-      const eDay = schedule.duration.substr(17, 10);
-      schedule.startDay = sDay;
-      schedule.endDay = eDay;
-    });
-
-    majorNotices.forEach((notice) => {
-      if (notice.articleTitle.startsWith('[ 일반공지 ]')) {
-        fixedNotices.push(notice);
-      } else nonfixedNotices.push(notice);
-    });
-
-    localStorageSet({ schedules, fixedNotices, nonfixedNotices });
+    preprocessAndUpload(schedules, majorNotices);
     localStorageSet(settingData(true, 1, 1, '정보컴퓨터공학부'));
     chrome.storage.local.get((result) => console.log(result)); // 크롬 개발자도구에선 확장프로그램의 로컬 스토리지를 볼 수 없다고 해서, 콘솔에 띄웁니다
   }


### PR DESCRIPTION
## 관련 이슈

- close #51

## 작업 내용

- 기존 service-worker.js에만 포함되어 있던 데이터 전처리 파트를
preprocess.js로 독립시키고 크롤링 할때마다 적용되도록 코드 개선.

## preview
